### PR TITLE
Rspec `before` defaults to `:each`, not `:all`

### DIFF
--- a/w7d1-rails-rspec/code/spec/models/bicycle_spec.rb
+++ b/w7d1-rails-rspec/code/spec/models/bicycle_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe Bicycle, type: :model do
   # to the Bicycle#description method defined in bicycle.rb
   context "description" do
 
-    # This will run ONCE before all following tests.
-    # If we wanted to run this before EACH test, we'd need to
-    # change it to `before :each`
+    # This will run before each of the following tests.
+    # If we wanted to run this once, before all the tests, we'd need to
+    # change it to `before :all`
     before do
       # Creating a few objects we'll use on our tests
       # Bicycles need Brands and Styles to be valid


### PR DESCRIPTION
[This](https://github.com/rspec/rspec-core/blob/fc767bef47807008899c24a8fd919236567c9023/lib/rspec/core/hooks.rb#L15) is where they name the default and [this](https://github.com/rspec/rspec-core/blob/fc767bef47807008899c24a8fd919236567c9023/lib/rspec/core/hooks.rb#L192-L193) is where they note that `:each` is the same as `:example`.
